### PR TITLE
Refactor deprecated traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate "test" as test_crate;
 
 use std::hash::Hash;
 use std::collections::hash_map::{self, HashMap, Hasher, Entry};
-use std::fmt::{self, Formatter, Show};
+use std::fmt::{self, Formatter, Debug};
 
 /// A `SequenceTrie` is recursively defined as a value and a map containing child Tries.
 ///
@@ -279,10 +279,10 @@ where
     }
 }
 
-impl<K, V> Show for SequenceTrie<K, V>
+impl<K, V> Debug for SequenceTrie<K, V>
 where
-    K: PartialEq + Eq + Hash<Hasher> + Clone + Show,
-    V: Show {
+    K: PartialEq + Eq + Hash<Hasher> + Clone + Debug,
+    V: Debug {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
         try!("Trie { value: ".fmt(fmt));
         try!(self.value.fmt(fmt));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ impl<K, V> SequenceTrie<K, V> where K: PartialEq + Eq + Hash<Hasher> + Clone {
 
         // Otherwise, recurse down the tree.
         match self.children.get(fragment) {
-            Some(node) => node.get_node(key.slice_from(1)),
+            Some(node) => node.get_node(&key[1..]),
             None => None
         }
     }
@@ -134,7 +134,7 @@ impl<K, V> SequenceTrie<K, V> where K: PartialEq + Eq + Hash<Hasher> + Clone {
 
         // Otherwise, recurse down the tree.
         match self.children.get_mut(fragment) {
-            Some(node) => node.get_mut_node(key.slice_from(1)),
+            Some(node) => node.get_mut_node(&key[1..]),
             None => None
         }
     }
@@ -204,7 +204,7 @@ impl<K, V> SequenceTrie<K, V> where K: PartialEq + Eq + Hash<Hasher> + Clone {
                 // Find the child entry in the node's hashmap.
                 if let Entry::Occupied(mut entry) = self.children.entry(fragment.clone()) {
                     // Work out whether to delete the child by calling remove recursively.
-                    let delete_child = entry.get_mut().remove_recursive(key.slice_from(1));
+                    let delete_child = entry.get_mut().remove_recursive(&key[1..]);
 
                     if delete_child {
                         entry.remove();


### PR DESCRIPTION
These changes refactor (rename really) the current implementation of the deprecated Show trait to implement the new Debug trait instead and change the uses of the from_slice method to the equivalent slice notation to remove the associated compiler warnings.